### PR TITLE
投稿とタグの紐付け情報削除メソッド

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -2,7 +2,6 @@ package db
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	// gormのmysql接続用
@@ -59,7 +58,6 @@ func GetDB() *gorm.DB {
 	initDB()
 	//
 	if tx != nil {
-		log.Printf("tx is not nil: %v", tx)
 		return tx
 	}
 	return DB

--- a/domain/model/join_post.go
+++ b/domain/model/join_post.go
@@ -2,6 +2,6 @@ package model
 
 // JoinPost 投稿情報の紐付け構造体
 type JoinPost struct {
-	Post *Post
-	Tags []PostTag
+	Post     *Post
+	PostTags []PostTag
 }

--- a/grpc/post_handler.go
+++ b/grpc/post_handler.go
@@ -30,8 +30,8 @@ func (s server) CreatePost(ctx context.Context, req *postservice.CreatePostReque
 	tags := makePostTagModel(postData)
 
 	joinPost := &model.JoinPost{
-		Post: post,
-		Tags: tags,
+		Post:     post,
+		PostTags: tags,
 	}
 
 	// post, tagsをJoinしてinteractor.Createに渡す
@@ -46,11 +46,7 @@ func (s server) CreatePost(ctx context.Context, req *postservice.CreatePostReque
 func (s server) DeletePost(ctx context.Context, req *postservice.DeletePostRequest) (*postservice.DeletePostResponse, error) {
 	id := req.GetId()
 
-	// 既に投稿が削除されていないかチェックする
-	post := &model.Post{
-		ID: id,
-	}
-	if err := s.PostUsecase.Delete(post); err != nil {
+	if err := s.PostUsecase.DeleteByID(id); err != nil {
 		return nil, err
 	}
 	return s.makeDeletePostResponse(StatusDeletePostSuccess), nil
@@ -80,7 +76,7 @@ func (s server) ListPost(req *postservice.ListPostRequest, stream postservice.Po
 
 func (s server) ReadPost(ctx context.Context, req *postservice.ReadPostRequest) (*postservice.ReadPostResponse, error) {
 	ID := req.GetId()
-	row, err := s.PostUsecase.Read(ID)
+	row, err := s.PostUsecase.GetByID(ID)
 	if err != nil {
 		return nil, err
 	}
@@ -99,8 +95,8 @@ func (s server) UpdatePost(ctx context.Context, req *postservice.UpdatePostReque
 	postData := req.GetPost()
 
 	joinPost := &model.JoinPost{
-		Post: makePostModel(postData),
-		Tags: makePostTagModel(postData),
+		Post:     makePostModel(postData),
+		PostTags: makePostTagModel(postData),
 	}
 	if _, err := s.PostUsecase.Update(joinPost.Post); err != nil {
 		return nil, err

--- a/usecase/interactor/post_Interactor.go
+++ b/usecase/interactor/post_Interactor.go
@@ -17,6 +17,8 @@ var (
 	err      error
 	post     model.Post
 	posts    []model.Post
+	postTag  model.PostTag
+	postTags []model.PostTag
 	rows     *sql.Rows
 	validate *validator.Validate
 )
@@ -30,21 +32,23 @@ var _ repository.PostRepository = (*PostInteractor)(nil)
 func (b *PostInteractor) Create(postData *model.JoinPost) (*model.JoinPost, error) {
 	validate = validator.New()
 	post := postData.Post
-	tags := postData.Tags
+	tags := postData.PostTags
 
 	// Post構造体のバリデーション
 	if err := validate.Struct(post); err != nil {
 		return postData, err
 	}
+
 	// トランザクション開始
 	tx := db.StartBegin()
+
 	// 投稿登録
 	if err := tx.Create(post).Error; err != nil {
 		db.EndRollback()
 		return postData, err
 	}
+
 	postID := post.ID
-	log.Println("created PostID", postID)
 	// 投稿とタグ紐付け情報登録
 	for _, tag := range tags {
 		tag.PostID = postID
@@ -53,16 +57,26 @@ func (b *PostInteractor) Create(postData *model.JoinPost) (*model.JoinPost, erro
 			return postData, err
 		}
 	}
-
+	// トランザクションを終了しコミット
 	db.EndCommit()
 	return postData, err
 }
 
-// Delete 投稿1件を削除
-func (b *PostInteractor) Delete(postData *model.Post) error {
-	DB := db.GetDB()
-	// 指定されたPostIDのPost, PostIDを共に削除
-	if err := DB.Delete(postData).Error; err != nil {
+// DeleteByID 指定されたIDに対する投稿1件を削除
+func (b *PostInteractor) DeleteByID(id uint32) error {
+	var post model.Post
+	var postTag model.PostTag
+
+	// トランザクション開始
+	tx := db.StartBegin()
+	// 指定されたPostIDのPostを削除
+	if err := tx.Where("id = ?", id).Delete(&post).Error; err != nil {
+		db.EndRollback()
+		return err
+	}
+	// 指定されたPostIDのPostTagを削除
+	if err := tx.Where("post_id = ?", id).Delete(&postTag).Error; err != nil {
+		db.EndRollback()
 		return err
 	}
 	return nil
@@ -115,8 +129,8 @@ func (b *PostInteractor) Update(postData *model.Post) (*model.Post, error) {
 	return postData, nil
 }
 
-// Read IDを元に投稿を1件取得する
-func (b *PostInteractor) Read(ID uint32) (model.Post, error) {
+// GetByID IDを元に投稿を1件取得する
+func (b *PostInteractor) GetByID(ID uint32) (model.Post, error) {
 	DB := db.GetDB()
 	row := DB.First(&post, ID)
 	if err := row.Error; err != nil {
@@ -128,3 +142,27 @@ func (b *PostInteractor) Read(ID uint32) (model.Post, error) {
 }
 
 // attachJoinData 投稿物の
+
+// listPostTagsByID PostIDを元にpostTagを検索し返す
+func listPostTagsByID(ID uint32) ([]model.PostTag, error) {
+	var postTagList []model.PostTag
+	DB := db.GetDB()
+	rows, err := DB.Where("post_id = ?", ID).Find(&postTags).Rows()
+	if err != nil {
+		log.Println("Error occured")
+		return nil, err
+	}
+	for rows.Next() {
+		DB.ScanRows(rows, &postTag)
+		postTagList = append(postTagList, postTag)
+	}
+
+	return postTagList, nil
+}
+
+func countPostTag() int {
+	var count int
+	DB := db.GetDB()
+	DB.Model(&postTag).Count(&count)
+	return count
+}

--- a/usecase/repository/repository.go
+++ b/usecase/repository/repository.go
@@ -5,7 +5,8 @@ import "github.com/yzmw1213/PostService/domain/model"
 // PostRepository 投稿サービスの抽象定義
 type PostRepository interface {
 	Create(*model.JoinPost) (*model.JoinPost, error)
-	Delete(*model.Post) error
+	GetByID(id uint32) (model.Post, error)
+	DeleteByID(id uint32) error
 	List() ([]model.Post, error)
 	Update(*model.Post) (*model.Post, error)
 }


### PR DESCRIPTION
- 投稿削除時に、タグとの紐付け情報も連動して削除