### PR TITLE
DB構造体を返却する際に新規接続しない修正

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -55,10 +55,13 @@ func Close() {
 
 // GetDB DB接続情報を返す
 func GetDB() *gorm.DB {
-	//
 	if tx != nil {
 		return tx
 	}
+	if DB == nil {
+		initDB()
+	}
+
 	return DB
 }
 

--- a/db/db.go
+++ b/db/db.go
@@ -55,7 +55,6 @@ func Close() {
 
 // GetDB DB接続情報を返す
 func GetDB() *gorm.DB {
-	initDB()
 	//
 	if tx != nil {
 		return tx


### PR DESCRIPTION
DB構造体を利用時に、毎回新規接続を行っていたために
"panic: Error: Too many connections" が発生していた。

毎回のリクエスト時にOpenは行わず、既存のコネクションを利用する形に修正
